### PR TITLE
AWS RDS SQL Server: small update to Server Host Name in Dsfhub assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - Aurora PostgreSQL CloudWatch with slow query auditing example
 
+### Bug Fixes
+- Modified Server Host Name of AWS RDS MS SQL SERVER Dsfhub assets
+
 ## 1.0.8 (2024-10-15)
 
 ### Features

--- a/examples/onboard-aws-rds-ms-sql-server/main.tf
+++ b/examples/onboard-aws-rds-ms-sql-server/main.tf
@@ -71,7 +71,7 @@ resource "terraform_data" "configure_database-2" {
     environment = {
       ADMIN_USER     = local.master_user
       ADMIN_PASSWORD = local.master_password
-      ENDPOINT       = module.aws-rds-ms-sql-server-2.rds-sql-server-instance[count.index].endpoint
+      ENDPOINT       = regex("(.*):", module.aws-rds-ms-sql-server-2.rds-sql-server-instance[count.index].endpoint)[0]
 
       SERVER_AUDIT_NAME      = local.server_audit_name
       SERVER_AUDIT_SPEC_NAME = local.server_audit_spec_name

--- a/modules/onboard-aws-rds-ms-sql-server/main.tf
+++ b/modules/onboard-aws-rds-ms-sql-server/main.tf
@@ -167,7 +167,7 @@ module "aws-rds-ms-sql-server-asset" {
   logs_destination_asset_id = module.s3-bucket.this.arn
   parent_asset_id           = var.aws_rds_mssql_parent_asset_id
   region                    = var.aws_rds_mssql_region
-  server_host_name          = module.rds-sql-server-db[count.index].this.endpoint
+  server_host_name          = regex("(.*):", module.rds-sql-server-db[count.index].this.endpoint)[0]
   server_port               = module.rds-sql-server-db[count.index].this.port
 }
 


### PR DESCRIPTION
Removes the extra `:1433` at the end